### PR TITLE
Fix UnicodeEncodeError for Python 2.7

### DIFF
--- a/src/configobj/__init__.py
+++ b/src/configobj/__init__.py
@@ -1215,8 +1215,11 @@ class ConfigObj(Section):
         except AttributeError:
             pass
 
-        if isinstance(infile, (six.string_types, Path)):
-            self.filename = str(infile)
+        if isinstance(infile, Path):
+            infile = str(infile)
+
+        if isinstance(infile, six.string_types):
+            self.filename = infile
             if os.path.isfile(infile):
                 with open(infile, 'rb') as h:
                     content = h.readlines() or []


### PR DESCRIPTION
Hello @mimi1vx,

These changes prevents an error when `infile` is a unicode string and it contains non-ascii characters.